### PR TITLE
Styled content inputs and button

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,22 +10,21 @@
     <div class="container">
         <h1>Currency Converter</h1>
         <div>
-            <label for="amount">Enter Amount:</label>
+            <h3>Enter Amount</h3> 
             <input type="number" id="amount" placeholder="100">
         </div>
-        <div>
-            <label for="fromCurrency"></label>
+        <div class="drop">
             <select id="fromCurrency" >
                     <option value="" disabled selected>USD - United States Dollar</option>
                     <option value="INR">INR - Indian Rupee</option>
                 
-            </select>
-     
-            <label for="toCurrency">To</label>
-            <select id="toCurrency">
+            </select> <h3> To </h3>   <select id="toCurrency">
                 <option value="" disabled selected>INR - Indian Rupee</option>
                     <option value="INR">USD - United States Dollar</option>
             </select>
+     
+          
+           
         </div>
         <button id="convert">Convert</button>
       

--- a/style.css
+++ b/style.css
@@ -2,14 +2,67 @@ body {
     font-family: 'Lato', sans-serif;
     background-color: #f4f4f4;
     margin: 0;
-    padding: 0;
+    padding: 20px;
     display: flex;
     justify-content: center;
     align-items: center;
     height: 100vh;
-    /* text-align: center; */
+    text-align: center;
+  }
+
+  .container{
+    background-color: #F8D800;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    width: 45%;
+    height: auto;  
+  }
+  .drop{
+    width: 70%;
+    height: 2%;
+    display: flex;
+   margin-left: 17%;
   }
 
   h1 {
     text-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
+  }
+
+  label, select, input, button {
+    /* display: block; */
+    width: 50%;
+    margin-bottom: 10px;
+    padding: 8px;
+    font-size: 16px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    /* text-align: center; */
+  }
+
+  input:focus, select:focus {
+    border-color: #555;
+    box-shadow: 0 0 5px rgba(85, 85, 85, 0.5);
+  }
+
+  input, select {
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    cursor: pointer;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  button:hover {
+    background-color: #0056b3;
+  }
+
+  button:active {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
   }


### PR DESCRIPTION
- 
- Closes #7 
- Set the background color of the content section to #F8D800 and center-aligned the text.
- Adjusted the content section's height to auto, added a slight shadow, and rounded the corners.
- Highlighted the input field with a border color of #555 on focus.
- Applied a slight shadow and rounded corners to the input fields and dropdowns.
- Styled the "Convert" button with a blue background (#007bff), white text, and a slight shadow for depth.
- Enhanced input field styling to match the design.

- ![image](https://github.com/user-attachments/assets/58f70814-ddb3-40b0-a5d6-5b0d7a4086d4)
